### PR TITLE
Fix invoice response items

### DIFF
--- a/Xendit.net/Xendit.net/Struct/InvoiceParameter.cs
+++ b/Xendit.net/Xendit.net/Struct/InvoiceParameter.cs
@@ -57,7 +57,7 @@
         [JsonPropertyName("reminder_time")]
         public int? ReminderTime { get; set; }
 
-        [JsonPropertyName("invoice")]
+        [JsonPropertyName("items")]
         public ItemInvoice[] Items { get; set; }
 
         [JsonPropertyName("customer")]


### PR DESCRIPTION
The InvoiceParameter items property was incorrectly attributed as invoice. This PR fixes it which will allows customers to create invoices through the SDK correctly.